### PR TITLE
Add custom exception to expose Arpoone API error codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,4 +305,17 @@ The package throws exceptions in the following cases:
  - Invalid or missing phone number or email address.
  - SMS sending failures.
  - Email sending failures.
- - Ensure you handle exceptions appropriately in your application.
+
+When an SMS or Email fails to send, the package throws an `ArpooneRequestException`.
+You can obtain the code returned by the API using the `getArpooneErrorCode()` method:
+
+```php
+try {
+    $user->notify(new SomeNotification());
+} catch (\Controlink\LaravelArpoone\Exceptions\ArpooneRequestException $e) {
+    $code = $e->getArpooneErrorCode();
+    // Handle the code or message as needed
+}
+```
+
+Ensure you handle exceptions appropriately in your application.

--- a/src/Channels/Arpoone.php
+++ b/src/Channels/Arpoone.php
@@ -9,6 +9,7 @@ use Dflydev\DotAccessData\Data;
 use Illuminate\Notifications\Notification;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\RequestException;
+use Controlink\LaravelArpoone\Exceptions\ArpooneRequestException;
 use libphonenumber\NumberParseException;
 use libphonenumber\PhoneNumberFormat;
 use libphonenumber\PhoneNumberType;
@@ -370,14 +371,15 @@ class Arpoone
             // Converte o conteúdo da resposta para um objeto PHP
             $responseBody = $e->getResponse()->getBody()->getContents();
             $decodedResponse = json_decode($responseBody);
+
             // Verifica se o JSON foi decodificado corretamente
             if (json_last_error() === JSON_ERROR_NONE && isset($decodedResponse->messages[0]->error->code)) {
                 $errorCode = $decodedResponse->messages[0]->error->code;
-                throw new \Exception('Failed to send '. $type .': ' . $errorCode);
-            } else {
-                // Caso algo esteja errado no JSON ou na estrutura esperada
-                throw new \Exception('Failed to send ' . $type . ': Unexpected response format');
+                throw new ArpooneRequestException('Failed to send ' . $type . ': ' . $errorCode, $errorCode);
             }
+
+            // Caso algo esteja errado no JSON ou na estrutura esperada
+            throw new ArpooneRequestException('Failed to send ' . $type . ': Unexpected response format');
         }
     }
 

--- a/src/Exceptions/ArpooneRequestException.php
+++ b/src/Exceptions/ArpooneRequestException.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Controlink\LaravelArpoone\Exceptions;
+
+use Exception;
+
+/**
+ * Exception thrown when the Arpoone API returns an error.
+ */
+class ArpooneRequestException extends Exception
+{
+    /**
+     * Error code returned by the Arpoone API.
+     */
+    protected ?int $arpooneErrorCode;
+
+    public function __construct(string $message = "", ?int $errorCode = null, int $code = 0, ?Exception $previous = null)
+    {
+        $this->arpooneErrorCode = $errorCode;
+        parent::__construct($message, $code, $previous);
+    }
+
+    /**
+     * Get the error code returned by the Arpoone API.
+     */
+    public function getArpooneErrorCode(): ?int
+    {
+        return $this->arpooneErrorCode;
+    }
+}


### PR DESCRIPTION
## Summary
- create `ArpooneRequestException` for access to API error code
- update Arpoone channel to throw this exception
- document how to read error codes in README

## Testing
- `composer --version` *(fails: command not found)*
- `php -l src/Exceptions/ArpooneRequestException.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684213650ac4832799c16e9129181883